### PR TITLE
fix: stylelint-scss package is not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The following prettier plugins are used:
 - [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports)
   - Automatically orders, arranges, and removes unused imports.
 
+Use `npm run format` to format all relevant files within the project.
+
 ### Eslint
 
 The [.eslintrc.json file](./.eslintrc.json) is set up to use [overrides](https://eslint.org/docs/latest/use/configure/configuration-files#how-do-overrides-work) for each of the following file types: \*.js, \*.ts, \*spec.ts, \*.html, \*.json, and \*.md.
@@ -154,6 +156,8 @@ To help ensure all project files are linted, the following eslint plugins are us
   - Uses recommended rule set.
 - [eslint-config-prettier](https://www.npmjs.com/package/eslint-config-prettier)
   - Removes any rules that may conflict with prettier formatting.
+
+Use `npm run lint` to lint all relevant files within the project.
 
 ### Stylelint
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ To help ensure all project files are linted, the following eslint plugins are us
 
 ### Stylelint
 
-Uses [stylelint](https://stylelint.io/) and the [stylelint-scss plugin](https://www.npmjs.com/package/stylelint-scss) to lint CSS and SCSS using the recommended rule sets for both. Rules for stylelint can be modified in the [.stylelintrc.json file](./.stylelintrc.json).
+Uses [Stylelint](https://stylelint.io/) to lint CSS and SCSS using the [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard) and [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) configurations.
+
+Rules for stylelint are split between \*.css & \*.scss overrides and can be modified in the [.stylelintrc.json file](./.stylelintrc.json).
+
+Use `npm run lint:style` to lint all styles within the project.
 
 ### VSCode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         "stylelint": "^16.2.0",
         "stylelint-config-standard": "^36.0.0",
         "stylelint-config-standard-scss": "^13.0.0",
-        "stylelint-scss": "^6.1.0",
         "tsc-files": "^1.1.4",
         "typescript": "~5.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "stylelint": "^16.2.0",
     "stylelint-config-standard": "^36.0.0",
     "stylelint-config-standard-scss": "^13.0.0",
-    "stylelint-scss": "^6.1.0",
     "tsc-files": "^1.1.4",
     "typescript": "~5.3.2"
   }


### PR DESCRIPTION
I re-read the [stylelint-scss documentation](https://github.com/stylelint-scss/stylelint-scss) where it states, "This plugin is used in the [stylelint-config-standard-scss shared config](https://github.com/stylelint-scss/stylelint-config-standard-scss). We recommend using that shared config, rather than installing this plugin directly."

[stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) is already installed and in use. I removed the unneeded `stylelint-scss` package from the devDependencies.

Since this only a dev dependency, I will make it a 'patch' change.