### PR TITLE
fix: cspell fails on hook

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -8,6 +8,7 @@
     "Catppuccin",
     "commitlint",
     "Darcula",
+    "devkit",
     "Fira",
     "Intellicode",
     "joematthews",
@@ -22,12 +23,5 @@
   // This is useful for offensive words and common spelling errors.
   // For example "hte" should be "the"
   "flagWords": [],
-  "caseSensitive": false,
-  "ignorePaths": [
-    ".stylelintrc.json",
-    ".vscode/*",
-    ".husky/*",
-    "angular.json",
-    "package.json"
-  ]
+  "caseSensitive": false
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint \"**/*.{js,ts,html,json,md}\"",
     "lint:style": "stylelint \"**/*.{css,scss}\"",
     "format": "prettier --write \"**/*.{js,ts,css,sh,html,md,json,yaml,yml}\"",
-    "check-selling": "cspell \"**/*\"",
+    "check-spelling": "cspell \"**/*\"",
     "prepare": "husky install"
   },
   "private": true,


### PR DESCRIPTION
cspell is not using ignorePaths from .cspell.json when called from lint-staged

resolves #20