### PR TITLE
fix(server.ts & main.ts): resolve eslint errors

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,11 @@ export function app(): express.Express {
   server.get('*', (req, res, next) => {
     const { protocol, originalUrl, baseUrl, headers } = req;
 
+    if (!headers.host)
+      throw new Error(
+        'cannot execute commonEngine.render: headers.host is undefined',
+      );
+
     commonEngine
       .render({
         bootstrap,
@@ -40,7 +45,7 @@ export function app(): express.Express {
         providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
       })
       .then((html) => res.send(html))
-      .catch((err) => {
+      .catch((err: unknown) => {
         next(err);
       });
   });
@@ -54,7 +59,9 @@ function run(): void {
   // Start up the Node server
   const server = app();
   server.listen(port, () => {
-    console.log(`Node Express server listening on http://localhost:${port}`);
+    console.log(
+      `Node Express server listening on http://localhost:${port.toString()}`,
+    );
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,6 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
 
-bootstrapApplication(AppComponent, appConfig).catch((err) => {
+bootstrapApplication(AppComponent, appConfig).catch((err: unknown) => {
   console.error(err);
 });


### PR DESCRIPTION
re #38

Missed a few eslint errors when I added additional eslint rules.

Explicitly set returned errors to 'unknown' instead of using the implicit any.

Used `.toString()` in template literals when the variable could be a string or number.

Throw error if req.headers.host is undefined before returning a result.